### PR TITLE
Add `--debug` command line option and `excludeConditions` feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ The CLI has three subcommands, to use the three main features of Textricator:
         See the [Form](#form) section for details.
         If your PDF has a tabular layout, see the [Table](#table) section.
 
+## Logging
+
+Add the `--debug` flag to log everything.
+
 ## Extracting text
 
 To extract the text from a PDF, run

--- a/README.md
+++ b/README.md
@@ -50,19 +50,6 @@ The CLI has three subcommands, to use the three main features of Textricator:
         See the [Form](#form) section for details.
         If your PDF has a tabular layout, see the [Table](#table) section.
 
-## Illegal Reflective Access Warning
-
-You may see the following warning printed:
-
-    WARNING: An illegal reflective access operation has occurred
-    WARNING: Illegal reflective access by org.parboiled.transform.AsmUtils (file:/F:/pathto/lib/parboiled-java-1.3.1.jar) to method java.lang.ClassLoader.findLoadedClass(java.lang.String)
-    WARNING: Please consider reporting this to the maintainers of org.parboiled.transform.AsmUtils
-    WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
-    WARNING: All illegal access operations will be denied in a future release
-
-Textricator still works, it is just a warning printed by a library Textricator uses.
-See [Issue #18](https://github.com/measuresforjustice/textricator/issues/18).
-
 ## Extracting text
 
 To extract the text from a PDF, run

--- a/README.md
+++ b/README.md
@@ -635,6 +635,22 @@ recordTypes:
     pagePriority: 2
 ```
 
+#### Exclude 
+
+Text segments can be excluded before processing by the finite-state machine
+by adding condition name to the `excludeConditions` list.
+If any of the conditions match, the text segment is excluded.
+
+For example, to exclude all text segments that consist solely of underscores:
+
+```yaml
+excludeConditions:
+  - underline
+  
+conditions:
+  underline: 'text =~ /_+/'
+```
+
 #### Starting new records for each value
 
 TODO

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>io.mfj</groupId>
   <artifactId>textricator</artifactId>
-  <version>10.0-SNAPSHOT</version>
+  <version>10.1-SNAPSHOT</version>
 
   <name>${project.groupId}:${project.artifactId}</name>
   <description>A tool to extract text from documents and generate structured data</description>

--- a/pom.xml
+++ b/pom.xml
@@ -149,14 +149,13 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
-      <version>1.7.30</version>
+      <version>1.7.32</version>
       <!-- MIT -->
     </dependency>
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-simple</artifactId>
-      <version>1.7.30</version>
-      <!-- MIT -->
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <version>1.2.3</version>
     </dependency>
 
     <dependency>

--- a/src/main/java/io/mfj/textricator/cli/TextricatorCli.kt
+++ b/src/main/java/io/mfj/textricator/cli/TextricatorCli.kt
@@ -25,7 +25,12 @@ import io.mfj.textricator.text.toPageFilter
 
 import java.io.File
 
+import ch.qos.logback.classic.Logger
+import ch.qos.logback.classic.Level
+
 import org.docopt.Docopt
+
+import org.slf4j.LoggerFactory
 
 /**
  * Command-line interface to [Textricator].
@@ -46,9 +51,9 @@ object TextricatorCli {
     Output is to standard out if not specified.
 
     Usage:
-      textricator text [--pages=<pages>] [--max-row-distance=<max-row-distance>] [--box-precision=<points>] [--box-ignore-colors=<colors>] [--input-format=<input-format>] [--output-format=<output-format>] <input> [<output>]
-      textricator form --config=<config> [--pages=<pages>] [--input-format=<input-format>] [--output-format=<output-format>] <input> [<output>]
-      textricator table --config=<config> [--pages=<pages>] [--input-format=<input-format>] [--output-format=<output-format>] <input> [<output>]
+      textricator text [--debug] [--pages=<pages>] [--max-row-distance=<max-row-distance>] [--box-precision=<points>] [--box-ignore-colors=<colors>] [--input-format=<input-format>] [--output-format=<output-format>] <input> [<output>]
+      textricator form [--debug] --config=<config> [--pages=<pages>] [--input-format=<input-format>] [--output-format=<output-format>] <input> [<output>]
+      textricator table [--debug] --config=<config> [--pages=<pages>] [--input-format=<input-format>] [--output-format=<output-format>] <input> [<output>]
       textricator -h | --help
       textricator --version
 
@@ -67,6 +72,7 @@ object TextricatorCli {
                                     ${Textricator.RECORD_OUTPUT_FORMAT_JSON}
                                     ${Textricator.RECORD_OUTPUT_FORMAT_JSON_FLAT}
                                     ${Textricator.RECORD_OUTPUT_FORMAT_NULL} (no output)
+      --debug                     Enable debug logging
       --version                   Show version, copyright, and license information.
     """.trimIndent().trim()
 
@@ -82,6 +88,10 @@ object TextricatorCli {
         .withHelp(true)
         .withExit(true)
         .parse(args.toList())
+
+    if (opts.boolean("--debug")) {
+      ( LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME) as Logger ).level = Level.DEBUG
+    }
 
     try {
       when {

--- a/src/main/java/io/mfj/textricator/form/FsmEventListener.kt
+++ b/src/main/java/io/mfj/textricator/form/FsmEventListener.kt
@@ -26,6 +26,7 @@ interface FsmEventListener {
   fun onFooter( text:Text)
   fun onLeftMargin( text:Text)
   fun onRightMargin( text:Text)
+  fun onExclude( text:Text, condition:String )
 
   fun onCheckTransition( currentState:String, condition:String, nextState:String )
   fun onCheckTransition( currentState:String, condition:String, nextState:String, match:Boolean, message:String? )

--- a/src/main/java/io/mfj/textricator/form/LoggingEventListener.kt
+++ b/src/main/java/io/mfj/textricator/form/LoggingEventListener.kt
@@ -47,7 +47,11 @@ object LoggingEventListener: FormParseEventListener {
   }
 
   override fun onRightMargin(text:Text) {
-    log.debug("\tpart of rigth gutter. skip")
+    log.debug("\tpart of right gutter. skip")
+  }
+
+  override fun onExclude(text: Text, condition: String) {
+    log.debug("\texcluded by condition \"${condition}\"")
   }
 
   override fun onCheckTransition(currentState:String, condition:String, nextState:String) {

--- a/src/main/java/io/mfj/textricator/form/WriterEventListener.kt
+++ b/src/main/java/io/mfj/textricator/form/WriterEventListener.kt
@@ -47,7 +47,11 @@ class WriterEventListener(private val w:Writer): FormParseEventListener {
   }
 
   override fun onRightMargin(text:Text) {
-    write("\tpart of rigth gutter. skip")
+    write("\tpart of right gutter. skip")
+  }
+
+  override fun onExclude(text: Text, condition: String) {
+    write("\texcluded by condition \"${condition}\"")
   }
 
   override fun onCheckTransition(currentState:String, condition:String, nextState:String) {

--- a/src/main/java/io/mfj/textricator/form/config/FormParseConfig.kt
+++ b/src/main/java/io/mfj/textricator/form/config/FormParseConfig.kt
@@ -37,6 +37,9 @@ class FormParseConfig(
     override var rootRecordType: String = "root",
     override var recordTypes: Map<String, RecordType> = emptyMap(),
     override var valueTypes: Map<String, ValueType> = emptyMap(),
+    /** Any [Text]s that match any of these condition names (the key in [conditions])
+     *  are excluded; never processed by the finite-state machine. */
+    var excludeConditions: List<String> = emptyList(),
     extractor:String? = null,
     pages:String? = null,
     maxRowDistance:Float = 0f,


### PR DESCRIPTION
Remove warning about illegal reflective access that has been fixe (#18).

Switch from `slf4j-simple` to `logback-classic` and add `--debug` command line options, which is way easier than setting `JAVA_OPTS=-Dorg.slf4j.simpleLogger.defaultLogLevel=debug`

Add `FormParseConfig.excludeConditions` which excludes all text segments that match any of the conditions before processing by the finite-state machine.