### PR TITLE
Ability to parse multiple files and write to one output

### DIFF
--- a/README.md
+++ b/README.md
@@ -810,6 +810,12 @@ Filtering happens after replacements and before member include checking.
 This allows splitting a field (e.g.: extracting a year from a date)
 to use in the filter, and not including the split field in the output.
 
+#### Processing multiple files together
+
+Multiple files using the same form config can be parsed and written to a single output
+with the `forms` CLI subcommand or with `io.mfj.textricator.Textricator.parseForms`.
+The output will include the source file name for each record.
+
 ## Extractors
 
 Extractors extract text (instances of `io.mfj.textricator.text.Text`) from a source.

--- a/src/main/java/io/mfj/textricator/cli/TextricatorCli.kt
+++ b/src/main/java/io/mfj/textricator/cli/TextricatorCli.kt
@@ -24,6 +24,7 @@ import io.mfj.textricator.table.config.TableParseConfigUtil
 import io.mfj.textricator.text.toPageFilter
 
 import java.io.File
+import java.io.InputStream
 
 import ch.qos.logback.classic.Logger
 import ch.qos.logback.classic.Level
@@ -53,6 +54,7 @@ object TextricatorCli {
     Usage:
       textricator text [--debug] [--pages=<pages>] [--max-row-distance=<max-row-distance>] [--box-precision=<points>] [--box-ignore-colors=<colors>] [--input-format=<input-format>] [--output-format=<output-format>] <input> [<output>]
       textricator form [--debug] --config=<config> [--pages=<pages>] [--input-format=<input-format>] [--output-format=<output-format>] <input> [<output>]
+      textricator forms [--debug] --config=<config> --input-format=<input-format> [--output-format=<output-format>] <input-dir> [<output>]
       textricator table [--debug] --config=<config> [--pages=<pages>] [--input-format=<input-format>] [--output-format=<output-format>] <input> [<output>]
       textricator -h | --help
       textricator --version
@@ -99,6 +101,7 @@ object TextricatorCli {
         opts.boolean("text") -> text(opts)
         opts.boolean("table") -> table(opts)
         opts.boolean("form") -> form(opts)
+        opts.boolean("forms") -> forms(opts)
       }
     } catch ( e:SystemExitException) {
       System.err.println(e.message)
@@ -197,6 +200,43 @@ object TextricatorCli {
     }
 
 
+  }
+
+  private fun forms( opts:Map<String,Any> ) {
+
+    val inputDir = opts.file("<input-dir>")!!
+
+    val inputFormat = opts.string("--input-format")!!
+    val inputFormatUpper = inputFormat.uppercase()
+
+    val outputFile = opts.file("<output>")
+    if ( outputFile != null ) outputFile.absoluteFile.parentFile.mkdirs()
+    val outputFormat = opts.string("--output-format") ?:
+      if ( outputFile == null ) {
+        throw SystemExitException( "--output-format is required if <output> is omitted.", 1 )
+      } else {
+        outputFile.extension.lowercase()
+      }
+
+    val configFile = opts.file("--config")!!
+
+    val config = FormParseConfigUtil.parseYaml(configFile)
+
+    val inputs:Sequence<Triple<String,()->InputStream,String>> = inputDir.walk().asSequence()
+        .filter { file -> file.isFile }
+        .filter { file -> file.extension.uppercase() == inputFormatUpper }
+        .sorted()
+        .map { inputFile ->
+          Triple( inputFile.relativeTo(inputDir).path, { inputFile.inputStream() }, inputFormat )
+        }
+
+    ( outputFile?.outputStream() ?: System.out ).use { output ->
+      Textricator.parseForms(
+        inputs = inputs,
+        output = output, outputFormat = outputFormat,
+        config = config
+      )
+    }
   }
 
   private fun table( opts:Map<String,Any> ) {

--- a/src/main/java/io/mfj/textricator/form/StateValue.kt
+++ b/src/main/java/io/mfj/textricator/form/StateValue.kt
@@ -22,5 +22,5 @@ import io.mfj.textricator.record.Value
 /**
  * @param pageNumber The pageNumber that the state started on.
  */
-data class StateValue( val pageNumber:Int, val stateId:String, val state:State, val values:List<Value>,
+data class StateValue( val source:String?, val pageNumber:Int, val stateId:String, val state:State, val values:List<Value>,
     val splitContinuation:Boolean=false )

--- a/src/main/java/io/mfj/textricator/record/Record.kt
+++ b/src/main/java/io/mfj/textricator/record/Record.kt
@@ -20,11 +20,19 @@ import java.beans.Transient
 
 // cannot be a data class, because used as a map key in RecordParser.
 class Record(
+    val source:String?=null,
     val pageNumber:Int,
     val typeId:String,
     val values:MutableMap<String,Value> = mutableMapOf(),
     val children:MutableMap<String,MutableList<Record>> = mutableMapOf()
 ) {
+
+  constructor(
+    pageNumber:Int,
+    typeId:String,
+    values:MutableMap<String,Value> = mutableMapOf(),
+    children:MutableMap<String,MutableList<Record>> = mutableMapOf()
+  ) : this(null,pageNumber,typeId,values,children)
 
   val isLeaf:Boolean
     @Transient

--- a/src/main/java/io/mfj/textricator/record/output/CsvRecordOutput.kt
+++ b/src/main/java/io/mfj/textricator/record/output/CsvRecordOutput.kt
@@ -28,7 +28,8 @@ import java.io.OutputStreamWriter
 
 import kotlinx.coroutines.channels.ReceiveChannel
 
-class CsvRecordOutput(private val config:RecordModel, output:OutputStream):RecordOutput {
+class CsvRecordOutput(private val config:RecordModel, output:OutputStream,
+  private val includeSource:Boolean=false ):RecordOutput {
 
   private val w = BufferedWriter(OutputStreamWriter(output))
 
@@ -59,6 +60,7 @@ class CsvRecordOutput(private val config:RecordModel, output:OutputStream):Recor
 
   private fun printHeader(p:CSVPrinter) {
 
+    if ( includeSource ) p.print("source")
     p.print("page")
 
     fun printType( recordType:RecordType) {
@@ -134,6 +136,7 @@ class CsvRecordOutput(private val config:RecordModel, output:OutputStream):Recor
 
     printType(rootRecordType)
 
+    if ( includeSource ) p.print( map[rootRecordType]!!.source )
     p.print( pageNumber )
     p.printRecord( cells )
 

--- a/src/main/java/io/mfj/textricator/record/output/JsonFlatRecordOutput.kt
+++ b/src/main/java/io/mfj/textricator/record/output/JsonFlatRecordOutput.kt
@@ -31,7 +31,7 @@ import com.fasterxml.jackson.core.JsonGenerator
 import com.fasterxml.jackson.databind.ObjectMapper
 import kotlinx.coroutines.channels.ReceiveChannel
 
-class JsonFlatRecordOutput(private val config:RecordModel, output:OutputStream):
+class JsonFlatRecordOutput(private val config:RecordModel, output:OutputStream, private val includeSource:Boolean):
     RecordOutput {
 
   private val w = BufferedWriter(OutputStreamWriter(output))
@@ -90,6 +90,7 @@ class JsonFlatRecordOutput(private val config:RecordModel, output:OutputStream):
   private fun printHeader() {
 
     val row:MutableMap<String,String> = mutableMapOf()
+    if ( includeSource ) row["source"] = "source"
     row["page"] = "page"
 
     fun print( recordType:RecordType) {
@@ -167,6 +168,9 @@ class JsonFlatRecordOutput(private val config:RecordModel, output:OutputStream):
 
     printType(rootRecordType)
 
+    if ( includeSource ) {
+      row["source"] = map[rootRecordType]!!.source ?: ""
+    }
     row["page"] = pageNumber.toString()
 
     writer.writeValue(w,row)

--- a/src/main/java/io/mfj/textricator/table/TableParser.kt
+++ b/src/main/java/io/mfj/textricator/table/TableParser.kt
@@ -107,7 +107,7 @@ class TableParser( private val config:TableParseConfig) {
     // Create a single record per row.
     // It has no children, just values.
 
-    val record = Record(pageNumber = pageNumber, typeId = ROOT_TYPE)
+    val record = Record(source=null, pageNumber = pageNumber, typeId = ROOT_TYPE)
 
     config.cols.keys
         .forEachIndexed { i, colName ->

--- a/src/test/java/io/mfj/textricator/form/NodeMembersTest.kt
+++ b/src/test/java/io/mfj/textricator/form/NodeMembersTest.kt
@@ -42,6 +42,7 @@ class NodeMembersTest {
   val rp = RecordParser(model)
 
   private fun sv(pageNumber: Int, stateId: String, vararg value: String) :StateValue = StateValue(
+      source = "test",
       pageNumber = pageNumber, stateId = stateId,
       state = model.states[stateId] ?: throw Exception("Missing State: ${stateId}"), values = value.toList().map{ Value(it) })
 

--- a/src/test/java/io/mfj/textricator/form/PatternReplacementTest.kt
+++ b/src/test/java/io/mfj/textricator/form/PatternReplacementTest.kt
@@ -44,7 +44,8 @@ class PatternReplacementTest {
   val rp = RecordParser(model)
 
   private fun sv(pageNumber: Int, stateId: String, vararg value: String) :StateValue = StateValue(
-      pageNumber = pageNumber, stateId = stateId,
+    source = "test",
+    pageNumber = pageNumber, stateId = stateId,
       state = model.states[stateId] ?: throw Exception("Missing State: ${stateId}"), values = value.toList().map{ Value(it) })
 
   @Test

--- a/src/test/java/io/mfj/textricator/form/RecordParserTest.kt
+++ b/src/test/java/io/mfj/textricator/form/RecordParserTest.kt
@@ -46,7 +46,8 @@ class RecordParserTest {
   val rp = RecordParser(model)
 
   private fun sv( pageNumber:Int, stateId:String, vararg value:String ):StateValue = StateValue(
-      pageNumber = pageNumber, stateId = stateId,
+    source = "test",
+    pageNumber = pageNumber, stateId = stateId,
       state = model.states[stateId] ?: throw Exception("Missing state ${stateId}"), values = value.toList().map{ Value(it) })
 
   @Test
@@ -139,19 +140,22 @@ class RecordParserTest {
     )
     val stateValues = listOf(
         StateValue(
+            source = "test",
             pageNumber = 1,
             values = listOf( Value("Fred") ),
             state = model.states["name"]!!,
             stateId = "name"
         ),
         StateValue(
+            source = "test",
             pageNumber = 1,
             values = listOf( Value("label") ),
             state = model.states["label"]!!,
             stateId = "label"
         ),
         StateValue(
-            pageNumber = 1,
+          source = "test",
+          pageNumber = 1,
             values = listOf( Value("Sally") ),
             state = model.states["name"]!!,
             stateId = "name"


### PR DESCRIPTION
Using the `forms` CLI subcommand or `Textricator.parseForms` you can now parse multiple form PDFs using the same config and write them to a single output, with the source file name included in each record.