### PR TITLE
Improve logging configuration.

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,13 @@ The CLI has three subcommands, to use the three main features of Textricator:
 
 ## Logging
 
-Add the `--debug` flag to log everything.
+Use the `--debug` flag to log everything.
+Logging is written to standard error.
+
+Textricator uses [SLF4J](https://slf4j.org) for logging, with the [Logback](https://logback.qos.ch) implementation.
+If you are using Textricator as a library, you may want to exclude `ch.qos.logback:logback-classic`.
+Textricator does *not* include a `/logback.xml`, so it will not conflict with other logging configurations,
+so long as `TextricatorCli.main()` is not invoked.
 
 ## Extracting text
 

--- a/pom.xml
+++ b/pom.xml
@@ -155,13 +155,13 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
-      <version>1.7.32</version>
+      <version>2.0.9</version>
       <!-- MIT -->
     </dependency>
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>1.2.9</version>
+      <version>1.4.11</version>
     </dependency>
 
     <dependency>

--- a/src/main/java/io/mfj/textricator/cli/TextricatorCli.kt
+++ b/src/main/java/io/mfj/textricator/cli/TextricatorCli.kt
@@ -85,6 +85,10 @@ object TextricatorCli {
   @JvmStatic
   fun main(args: Array<String>) {
 
+    // setup logging. This is done in main() (as opposed to with a logback.xml) so applications using Textricator
+    // as a library are not affected by our logging config.
+    System.setProperty("logback.configurationFile", "io/mfj/textricator/logback.xml")
+
     val opts = Docopt(help)
         .withHelp(true)
         .withExit(true)

--- a/src/main/resources/io/mfj/textricator/logback.xml
+++ b/src/main/resources/io/mfj/textricator/logback.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE configuration>
+
+<configuration>
+    <import class="ch.qos.logback.classic.encoder.PatternLayoutEncoder"/>
+    <import class="ch.qos.logback.core.ConsoleAppender"/>
+
+    <appender name="STDERR" class="ConsoleAppender">
+        <target>System.err</target>
+        <encoder class="PatternLayoutEncoder">
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger -%kvp- %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="WARN">
+        <appender-ref ref="STDERR"/>
+    </root>
+</configuration>


### PR DESCRIPTION
Logging is configured in `main()` as to not conflict with code using Textricator as a library.

Logging is now written to stderr instead of stdout.

Updated versions of slf4j and logback.