### PR TITLE
Setting up Code Ownership by way of CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,8 @@
+# This is the CODEOWNERS file for the textricator repo.
+
+# These owners will be the default owners for everything in the repo, unless a
+# later match takes precedence.
+*   @lschumann-mfj @wstumbo-mfj
+
+# Make sure that DevOps is aware of anything GitHub related
+/.github/    @lschumann-mfj @wstumbo-mfj @SB-MFJ @meghanbissonnette-mfj


### PR DESCRIPTION
Refers to [sc-74092]; Creates CODEOWNERS file and sets it to the intended owners of this repo!